### PR TITLE
Fix compilation error in enc-read-string

### DIFF
--- a/cl-postgres/strings-utf-8.lisp
+++ b/cl-postgres/strings-utf-8.lisp
@@ -13,7 +13,7 @@
 
 (declaim (inline enc-read-string))
 (declaim (ftype (function (t &key (:null-terminated t)
-                                  (:byte-length unsigned-byte))
+                                  (:byte-length fixnum))
                           string)
                 enc-read-string))
 (defun enc-read-string (input &key null-terminated (byte-length -1))


### PR DESCRIPTION
Change the ftype of enc-read-string so the default value of -1 does not raise a compilation error.